### PR TITLE
Add a couple of features provided by gulp-cheerio

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ module.exports = {
     }),
     new CheerioWebpackPlugin({
       test: /.html$/,
-      callback: function ($) {
+      callback: function ($, filename) { // filename provided as 2nd argument
         $('.debug').remove()
       }
     })

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ module.exports = {
       test: /.html$/,
       callback: function ($, filename) { // filename provided as 2nd argument
         $('.debug').remove()
+      },
+      parserOptions: { // custom parser options can be provided
+        xmlMode: true  // uses $.xml() instead of $.html() internally
       }
     })
   ]

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class CheerioWebpackPlugin {
       for (const filename in compilation.assets) {
         if (matchFile(filename, this.options.test)) {
           const $ = cheerio.load(compilation.assets[filename].source())
-          this.options.callback && this.options.callback($)
+          this.options.callback && this.options.callback($, filename)
 
           compilation.assets[filename] = {
             source: () => $.html(),

--- a/index.js
+++ b/index.js
@@ -21,12 +21,13 @@ class CheerioWebpackPlugin {
     compiler.hooks.emit.tapAsync('CheerioWebpackPlugin', (compilation, callback) => {
       for (const filename in compilation.assets) {
         if (matchFile(filename, this.options.test)) {
-          const $ = cheerio.load(compilation.assets[filename].source())
+          const $ = cheerio.load(compilation.assets[filename].source(), this.options.parserOptions)
           this.options.callback && this.options.callback($, filename)
+          const isXml = !!(this.options.parserOptions || {}).xmlMode;
 
           compilation.assets[filename] = {
-            source: () => $.html(),
-            size: () => $.html().size
+            source: () => isXml ? $.xml() : $.html(),
+            size: () => (isXml ? $.xml() : $.html()).size
           }
         }
       }


### PR DESCRIPTION
- Currently processed filename is provided as a 2nd argument to the callback, in order to allow different processing accordingly
- Cheerio [custom parser options](https://github.com/cheeriojs/cheerio#loading) are supported; if `xmlMode` is enabled, rendering is done using `$.xml()` rather than `$.html()`